### PR TITLE
Add multi-platform plugin support for Cursor and Codex

### DIFF
--- a/.claude/skills/implement-claude-extensions/SKILL.md
+++ b/.claude/skills/implement-claude-extensions/SKILL.md
@@ -22,13 +22,15 @@ See `references/decision-framework.md` for detailed scoring guide.
 
 ## Comparison
 
-| Extension Type | Best For                           | Primary Artifacts                | Component Skill                      |
-| -------------- | ---------------------------------- | -------------------------------- | ------------------------------------ |
-| Hooks          | Event-driven automation/guardrails | `hooks/hooks.json`, hook scripts | `../implement-hooks/SKILL.md`        |
-| Agent Skills   | Reusable task playbooks            | `skills/<name>/SKILL.md`         | `../implement-agent-skills/SKILL.md` |
-| Sub-Agents     | Specialized delegated roles        | `agents/*.md`                    | `../implement-sub-agents/SKILL.md`   |
-| Agent Teams    | Coordinated multi-agent execution  | team config + coordination docs  | `../implement-agent-teams/SKILL.md`  |
-| Plugins        | Packaging/distribution + wiring    | `.claude-plugin/plugin.json`     | `../implement-plugin/SKILL.md`       |
+| Extension Type      | Best For                           | Primary Artifacts                   | Component Skill                             |
+| ------------------- | ---------------------------------- | ----------------------------------- | ------------------------------------------- |
+| Hooks               | Event-driven automation/guardrails | `hooks/hooks.json`, hook scripts    | `../implement-hooks/SKILL.md`               |
+| Agent Skills        | Reusable task playbooks            | `skills/<name>/SKILL.md`            | `../implement-agent-skills/SKILL.md`        |
+| Sub-Agents          | Specialized delegated roles        | `agents/*.md`                       | `../implement-sub-agents/SKILL.md`          |
+| Agent Teams         | Coordinated multi-agent execution  | team config + coordination docs     | `../implement-agent-teams/SKILL.md`         |
+| Plugins (Claude)    | Packaging/distribution + wiring    | `.claude-plugin/plugin.json`        | `../implement-plugin/SKILL.md`              |
+| Plugins (Cursor)    | Cursor marketplace delivery        | `.cursor-plugin/plugin.json`, rules | `../implement-cursor-plugin/SKILL.md`       |
+| Plugins (Codex)     | Codex marketplace delivery         | `.codex-plugin/plugin.json`, assets | `../implement-codex-plugin/SKILL.md`        |
 
 ## Workflow
 
@@ -62,6 +64,8 @@ See `references/decision-framework.md` for detailed scoring guide.
 - `../implement-sub-agents/SKILL.md`
 - `../implement-agent-teams/SKILL.md`
 - `../implement-plugin/SKILL.md`
+- `../implement-cursor-plugin/SKILL.md`
+- `../implement-codex-plugin/SKILL.md`
 
 ## Sources
 

--- a/.claude/skills/implement-claude-extensions/SKILL.md
+++ b/.claude/skills/implement-claude-extensions/SKILL.md
@@ -22,15 +22,15 @@ See `references/decision-framework.md` for detailed scoring guide.
 
 ## Comparison
 
-| Extension Type      | Best For                           | Primary Artifacts                   | Component Skill                             |
-| ------------------- | ---------------------------------- | ----------------------------------- | ------------------------------------------- |
-| Hooks               | Event-driven automation/guardrails | `hooks/hooks.json`, hook scripts    | `../implement-hooks/SKILL.md`               |
-| Agent Skills        | Reusable task playbooks            | `skills/<name>/SKILL.md`            | `../implement-agent-skills/SKILL.md`        |
-| Sub-Agents          | Specialized delegated roles        | `agents/*.md`                       | `../implement-sub-agents/SKILL.md`          |
-| Agent Teams         | Coordinated multi-agent execution  | team config + coordination docs     | `../implement-agent-teams/SKILL.md`         |
-| Plugins (Claude)    | Packaging/distribution + wiring    | `.claude-plugin/plugin.json`        | `../implement-plugin/SKILL.md`              |
-| Plugins (Cursor)    | Cursor marketplace delivery        | `.cursor-plugin/plugin.json`, rules | `../implement-cursor-plugin/SKILL.md`       |
-| Plugins (Codex)     | Codex marketplace delivery         | `.codex-plugin/plugin.json`, assets | `../implement-codex-plugin/SKILL.md`        |
+| Extension Type   | Best For                           | Primary Artifacts                   | Component Skill                       |
+| ---------------- | ---------------------------------- | ----------------------------------- | ------------------------------------- |
+| Hooks            | Event-driven automation/guardrails | `hooks/hooks.json`, hook scripts    | `../implement-hooks/SKILL.md`         |
+| Agent Skills     | Reusable task playbooks            | `skills/<name>/SKILL.md`            | `../implement-agent-skills/SKILL.md`  |
+| Sub-Agents       | Specialized delegated roles        | `agents/*.md`                       | `../implement-sub-agents/SKILL.md`    |
+| Agent Teams      | Coordinated multi-agent execution  | team config + coordination docs     | `../implement-agent-teams/SKILL.md`   |
+| Plugins (Claude) | Packaging/distribution + wiring    | `.claude-plugin/plugin.json`        | `../implement-plugin/SKILL.md`        |
+| Plugins (Cursor) | Cursor marketplace delivery        | `.cursor-plugin/plugin.json`, rules | `../implement-cursor-plugin/SKILL.md` |
+| Plugins (Codex)  | Codex marketplace delivery         | `.codex-plugin/plugin.json`, assets | `../implement-codex-plugin/SKILL.md`  |
 
 ## Workflow
 

--- a/.claude/skills/implement-codex-plugin/SKILL.md
+++ b/.claude/skills/implement-codex-plugin/SKILL.md
@@ -53,6 +53,7 @@ plugins/<plugin-name>/
 Codex skills follow the same `SKILL.md` format as Claude Code skills. They live in the shared `skills/` directory and are automatically picked up by all platforms that support them.
 
 Frontmatter:
+
 ```markdown
 ---
 name: skill-name
@@ -63,6 +64,7 @@ description: What this skill does
 ## App Integrations (.app.json)
 
 Connect the plugin to third-party services:
+
 ```json
 {
   "integrations": [
@@ -78,6 +80,7 @@ Connect the plugin to third-party services:
 ## Marketplace Assets
 
 Place in `assets/`:
+
 - `icon.svg` or `icon.png` — Plugin icon (64×64 recommended)
 - `screenshot-*.png` — Up to 3 screenshots for the marketplace listing
 - `banner.png` — Optional banner image
@@ -90,6 +93,7 @@ Place in `assets/`:
 ## Validation
 
 Run before distribution:
+
 ```bash
 bash integration_tests/validate-codex-manifest.sh plugins/<plugin-name>
 ```

--- a/.claude/skills/implement-codex-plugin/SKILL.md
+++ b/.claude/skills/implement-codex-plugin/SKILL.md
@@ -35,7 +35,7 @@ Implement Codex plugin packaging: manifest authoring, skill reuse, app integrati
 
 ## Directory Layout
 
-```
+```text
 plugins/<plugin-name>/
 ├── .codex-plugin/
 │   └── plugin.json          # Codex manifest (required)

--- a/.claude/skills/implement-codex-plugin/SKILL.md
+++ b/.claude/skills/implement-codex-plugin/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: implement-codex-plugin
+description: Package and distribute Codex plugins with schema-safe manifests, skills, app config, marketplace assets, and release-ready validation.
+---
+
+# Implement Codex Plugin
+
+Implement Codex plugin packaging: manifest authoring, skill reuse, app integrations, marketplace assets, and distribution to the Codex plugin directory.
+
+## Workflow
+
+1. Create `.codex-plugin/plugin.json` with required `name`, `version`, `description` fields.
+2. Wire shared `skills/` directory from plugin root (reused across platforms).
+3. Optionally add `.app.json` for third-party app integrations.
+4. Add `assets/` with marketplace visuals (icon, screenshots).
+5. Validate manifest with `integration_tests/validate-codex-manifest.sh`.
+6. Prepare for distribution via Codex plugin directory.
+
+## Manifest Schema
+
+```json
+{
+  "name": "my-plugin",
+  "version": "1.0.0",
+  "description": "Brief description of what this plugin does",
+  "author": { "name": "your-name" },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/owner/repo",
+  "skills": "./skills/"
+}
+```
+
+**Required**: `name` (kebab-case), `version`, `description`
+**Optional**: `author`, `license`, `repository`, `skills` (path to skills directory)
+
+## Directory Layout
+
+```
+plugins/<plugin-name>/
+├── .codex-plugin/
+│   └── plugin.json          # Codex manifest (required)
+├── skills/
+│   └── <name>/SKILL.md      # Shared skills (also used by Claude Code, Cursor)
+├── .mcp.json                # MCP server config (shared across platforms)
+├── .app.json                # Third-party app integrations (Codex-specific)
+└── assets/
+    ├── icon.svg             # Plugin icon (64x64 recommended)
+    └── screenshot.png       # Marketplace screenshot
+```
+
+## Skills (SKILL.md)
+
+Codex skills follow the same `SKILL.md` format as Claude Code skills. They live in the shared `skills/` directory and are automatically picked up by all platforms that support them.
+
+Frontmatter:
+```markdown
+---
+name: skill-name
+description: What this skill does
+---
+```
+
+## App Integrations (.app.json)
+
+Connect the plugin to third-party services:
+```json
+{
+  "integrations": [
+    {
+      "name": "github",
+      "type": "oauth",
+      "scopes": ["repo", "read:user"]
+    }
+  ]
+}
+```
+
+## Marketplace Assets
+
+Place in `assets/`:
+- `icon.svg` or `icon.png` — Plugin icon (64×64 recommended)
+- `screenshot-*.png` — Up to 3 screenshots for the marketplace listing
+- `banner.png` — Optional banner image
+
+## Distribution
+
+- **Plugin directory**: Submit via the Codex developer portal (self-serve publishing coming soon)
+- **Local distribution**: Reference via marketplace JSON in a repository or personal directory
+
+## Validation
+
+Run before distribution:
+```bash
+bash integration_tests/validate-codex-manifest.sh plugins/<plugin-name>
+```
+
+## Component Skills
+
+- Shared skills: `../implement-agent-skills/SKILL.md`
+- MCP wiring: see `.mcp.json` in plugin root
+- Full plugin packaging: `../implement-plugin/SKILL.md`
+
+## Sources
+
+- https://developers.openai.com/codex/plugins/build

--- a/.claude/skills/implement-cursor-plugin/SKILL.md
+++ b/.claude/skills/implement-cursor-plugin/SKILL.md
@@ -49,11 +49,13 @@ plugins/<plugin-name>/
 ## Rules (.mdc files)
 
 Rules provide persistent AI guidance injected into every Cursor session. Use them for:
+
 - Coding standards and conventions
 - Project-specific patterns to follow or avoid
 - Context about the codebase architecture
 
 **Frontmatter fields**:
+
 ```markdown
 ---
 description: Brief description of what this rule enforces
@@ -77,6 +79,7 @@ alwaysApply: false
 ## Validation
 
 Run before distribution:
+
 ```bash
 bash integration_tests/validate-cursor-manifest.sh plugins/<plugin-name>
 ```

--- a/.claude/skills/implement-cursor-plugin/SKILL.md
+++ b/.claude/skills/implement-cursor-plugin/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: implement-cursor-plugin
+description: Package and distribute Cursor plugins with schema-safe manifests, rules, skills, MCP wiring, and release-ready validation.
+---
+
+# Implement Cursor Plugin
+
+Implement Cursor plugin packaging: manifest authoring, rules creation, skill reuse, MCP wiring, and distribution to the Cursor marketplace.
+
+## Workflow
+
+1. Create `.cursor-plugin/plugin.json` with required `name` field (kebab-case) and optional `version`, `description`.
+2. Add Cursor-specific `rules/` directory with `.mdc` files for persistent AI guidance.
+3. Wire shared `skills/` and `.mcp.json` from the plugin root (reused across platforms).
+4. Validate manifest with `integration_tests/validate-cursor-manifest.sh`.
+5. Prepare for distribution via the Cursor marketplace or team channel.
+
+## Manifest Schema
+
+```json
+{
+  "name": "my-plugin",
+  "version": "1.0.0",
+  "description": "Brief description of what this plugin does",
+  "author": { "name": "your-name" },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/owner/repo"
+}
+```
+
+**Required**: `name` (kebab-case: `^[a-z0-9-]+$`)
+**Optional**: `version`, `description`, `author`, `license`, `repository`
+
+## Directory Layout
+
+```
+plugins/<plugin-name>/
+├── .cursor-plugin/
+│   └── plugin.json          # Cursor manifest (required)
+├── rules/
+│   └── <name>.mdc           # Persistent AI guidance rules
+├── skills/
+│   └── <name>/SKILL.md      # Shared skills (also used by Claude Code, Codex)
+├── hooks/
+│   └── hooks.json           # Event-triggered automation (shared with Claude Code)
+└── .mcp.json                # MCP server config (shared across platforms)
+```
+
+## Rules (.mdc files)
+
+Rules provide persistent AI guidance injected into every Cursor session. Use them for:
+- Coding standards and conventions
+- Project-specific patterns to follow or avoid
+- Context about the codebase architecture
+
+**Frontmatter fields**:
+```markdown
+---
+description: Brief description of what this rule enforces
+globs:
+  - "**/*.ts"
+  - "src/**/*.py"
+alwaysApply: false
+---
+```
+
+- `globs`: File patterns where this rule activates
+- `alwaysApply: true`: Rule always injected regardless of file context
+
+## Distribution Channels
+
+- **Official Marketplace**: Submit via cursor.com/marketplace/publish (manually reviewed)
+- **Team Marketplace**: Available on Cursor Teams/Enterprise plans
+- **Community**: Listed at cursor.directory
+- **Local testing**: Install from `~/.cursor/plugins/local`
+
+## Validation
+
+Run before distribution:
+```bash
+bash integration_tests/validate-cursor-manifest.sh plugins/<plugin-name>
+```
+
+## Component Skills
+
+- Claude Code hooks (also work in Cursor): `../implement-hooks/SKILL.md`
+- Shared skills: `../implement-agent-skills/SKILL.md`
+- MCP wiring: see `.mcp.json` in plugin root
+- Full plugin packaging: `../implement-plugin/SKILL.md`
+
+## Sources
+
+- https://cursor.com/docs/plugins
+- https://cursor.directory

--- a/.claude/skills/implement-cursor-plugin/SKILL.md
+++ b/.claude/skills/implement-cursor-plugin/SKILL.md
@@ -33,7 +33,7 @@ Implement Cursor plugin packaging: manifest authoring, rules creation, skill reu
 
 ## Directory Layout
 
-```
+```text
 plugins/<plugin-name>/
 ├── .cursor-plugin/
 │   └── plugin.json          # Cursor manifest (required)

--- a/.claude/skills/implement-plugin/SKILL.md
+++ b/.claude/skills/implement-plugin/SKILL.md
@@ -31,12 +31,31 @@ Implement plugin-level packaging, manifest wiring, structure checks, runtime loa
 - Complete manifest template: `assets/templates/complete-plugin.json`
 - Manifest with components template: `assets/templates/plugin-with-components.json`
 
+## Multi-Platform Support
+
+A plugin directory can target multiple AI coding assistant platforms simultaneously. Add platform-specific manifest subdirectories alongside `.claude-plugin/`:
+
+| Platform   | Manifest Dir       | Required Fields              | Platform Skill                          |
+| ---------- | ------------------ | ---------------------------- | --------------------------------------- |
+| Claude Code | `.claude-plugin/` | `name`, `version`, `description` | *(this skill)*                     |
+| Cursor     | `.cursor-plugin/`  | `name`                       | `../implement-cursor-plugin/SKILL.md`   |
+| Codex      | `.codex-plugin/`   | `name`, `version`, `description` | `../implement-codex-plugin/SKILL.md` |
+
+Shared components (`skills/`, `.mcp.json`) live at the plugin root and are reused across all platforms that support them.
+
+Validate all platforms at once:
+```bash
+./integration_tests/run.sh --manifest-only --verbose
+```
+
 ## Component Skills
 
 - Hooks: `../implement-hooks/SKILL.md`
 - Agent Skills: `../implement-agent-skills/SKILL.md`
 - Sub-Agents: `../implement-sub-agents/SKILL.md`
 - Agent Teams: `../implement-agent-teams/SKILL.md`
+- Cursor plugins: `../implement-cursor-plugin/SKILL.md`
+- Codex plugins: `../implement-codex-plugin/SKILL.md`
 - Umbrella selection guide: `../implement-claude-extensions/SKILL.md`
 
 ## Sources

--- a/.claude/skills/implement-plugin/SKILL.md
+++ b/.claude/skills/implement-plugin/SKILL.md
@@ -35,15 +35,16 @@ Implement plugin-level packaging, manifest wiring, structure checks, runtime loa
 
 A plugin directory can target multiple AI coding assistant platforms simultaneously. Add platform-specific manifest subdirectories alongside `.claude-plugin/`:
 
-| Platform   | Manifest Dir       | Required Fields              | Platform Skill                          |
-| ---------- | ------------------ | ---------------------------- | --------------------------------------- |
-| Claude Code | `.claude-plugin/` | `name`, `version`, `description` | *(this skill)*                     |
-| Cursor     | `.cursor-plugin/`  | `name`                       | `../implement-cursor-plugin/SKILL.md`   |
-| Codex      | `.codex-plugin/`   | `name`, `version`, `description` | `../implement-codex-plugin/SKILL.md` |
+| Platform    | Manifest Dir      | Required Fields                  | Platform Skill                        |
+| ----------- | ----------------- | -------------------------------- | ------------------------------------- |
+| Claude Code | `.claude-plugin/` | `name`, `version`, `description` | _(this skill)_                        |
+| Cursor      | `.cursor-plugin/` | `name`                           | `../implement-cursor-plugin/SKILL.md` |
+| Codex       | `.codex-plugin/`  | `name`, `version`, `description` | `../implement-codex-plugin/SKILL.md`  |
 
 Shared components (`skills/`, `.mcp.json`) live at the plugin root and are reused across all platforms that support them.
 
 Validate all platforms at once:
+
 ```bash
 ./integration_tests/run.sh --manifest-only --verbose
 ```

--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "codex-plugin-template",
+  "metadata": {
+    "description": "Template repository for creating high-quality Codex plugins with shared CI/CD and testing infrastructure"
+  },
+  "owner": {
+    "name": "yu-iskw"
+  },
+  "plugins": [
+    {
+      "name": "hello-world",
+      "description": "Comprehensive sample plugin demonstrating all Codex extension points",
+      "source": "./plugins/hello-world",
+      "version": "1.0.0",
+      "author": {
+        "name": "yu-iskw"
+      },
+      "license": "Apache-2.0",
+      "repository": "https://github.com/yu-iskw/claude-code-plugin-template"
+    }
+  ]
+}

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "cursor-plugin-template",
+  "metadata": {
+    "description": "Template repository for creating high-quality Cursor plugins with shared CI/CD and testing infrastructure"
+  },
+  "owner": {
+    "name": "yu-iskw"
+  },
+  "plugins": [
+    {
+      "name": "hello-world",
+      "description": "Comprehensive sample plugin demonstrating all Cursor extension points",
+      "source": "./plugins/hello-world",
+      "version": "1.0.0",
+      "author": {
+        "name": "yu-iskw"
+      },
+      "license": "Apache-2.0",
+      "repository": "https://github.com/yu-iskw/claude-code-plugin-template"
+    }
+  ]
+}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -30,6 +30,20 @@ jobs:
       - name: Run all plugin integration tests
         run: ./integration_tests/run.sh --verbose
 
+  multi-platform-validation:
+    name: Multi-Platform Manifest Validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Run multi-platform manifest validation
+        run: ./integration_tests/run.sh --manifest-only --verbose
+
   plugin-install-docker:
     name: Plugin Install in Docker
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+actionlint

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Cursor MDC (Markdown with Components) files — no prettier parser available
+**/*.mdc

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,5 @@
 # Cursor MDC (Markdown with Components) files — no prettier parser available
 **/*.mdc
+
+# SVG files — no prettier parser available without plugins
+**/*.svg

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -6,9 +6,9 @@ cli:
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
-    - go@1.19.5
-    - node@20.19.0
-    - python@3.10.8
+    - go@1.25.9
+    - node@24.13.0
+    - python@3.11.0
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
@@ -18,7 +18,7 @@ lint:
     - git-diff-check
     - markdownlint@0.47.0
     - prettier@3.8.1
-    - trivy@0.58.2
+    - trivy@0.69.3
     - yamllint@1.38.0
   ignore:
     - linters: [prettier]

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -25,6 +25,7 @@ lint:
       paths:
         - "**/*.mdc"
         - "**/*.svg"
+        - .prettierignore
   disabled:
     - checkov
     - trufflehog

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -8,7 +8,7 @@ runtimes:
   enabled:
     - go@1.25.9
     - node@24.13.0
-    - python@3.11.0
+    - python@3.10.8
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -20,6 +20,11 @@ lint:
     - prettier@3.8.1
     - trivy@0.58.2
     - yamllint@1.38.0
+  ignore:
+    - linters: [prettier]
+      paths:
+        - "**/*.mdc"
+        - "**/*.svg"
   disabled:
     - checkov
     - trufflehog

--- a/integration_tests/run.sh
+++ b/integration_tests/run.sh
@@ -144,6 +144,16 @@ for plugin in "${PLUGINS[@]}"; do
 		# Test 3: Component discovery
 		run_test_nonfatal "Component discovery" "test-component-discovery.sh" "${plugin}"
 	fi
+
+	# Test 4: Cursor manifest validation (optional — only if .cursor-plugin exists)
+	if [[ -d "${plugin}/.cursor-plugin" ]]; then
+		run_test_nonfatal "Cursor manifest validation" "validate-cursor-manifest.sh" "${plugin}"
+	fi
+
+	# Test 5: Codex manifest validation (optional — only if .codex-plugin exists)
+	if [[ -d "${plugin}/.codex-plugin" ]]; then
+		run_test_nonfatal "Codex manifest validation" "validate-codex-manifest.sh" "${plugin}"
+	fi
 done
 
 # Summary

--- a/integration_tests/validate-codex-manifest.sh
+++ b/integration_tests/validate-codex-manifest.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 yu-iskw
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Validate Codex plugin manifest JSON schema and required fields
+set -euo pipefail
+
+# Default plugin directory
+PLUGIN_DIR="${1:-.}"
+MANIFEST_PATH="${PLUGIN_DIR}/.codex-plugin/plugin.json"
+
+# Check if manifest file exists
+if [[ ! -f ${MANIFEST_PATH} ]]; then
+	echo "ERROR: Codex manifest file not found: ${MANIFEST_PATH}"
+	exit 1
+fi
+
+# Detect available JSON validator (prefer jq, fallback to node)
+if command -v jq >/dev/null 2>&1; then
+	# Validate JSON structure
+	if ! jq -e . "${MANIFEST_PATH}" >/dev/null 2>&1; then
+		echo "ERROR: Invalid JSON structure in ${MANIFEST_PATH}."
+		exit 1
+	fi
+
+	# Check required fields: name, version, description
+	for field in name version description; do
+		if ! jq -e --arg field "${field}" '.[$field] | type == "string" and length > 0' "${MANIFEST_PATH}" >/dev/null 2>&1; then
+			echo "ERROR: Missing required non-empty string field '${field}' in ${MANIFEST_PATH}."
+			exit 1
+		fi
+	done
+
+	# Validate plugin name format (kebab-case)
+	plugin_name="$(jq -r '.name' "${MANIFEST_PATH}")"
+	if ! jq -e '.name | test("^[a-z0-9-]+$")' "${MANIFEST_PATH}" >/dev/null 2>&1; then
+		echo "ERROR: Invalid plugin name '${plugin_name}'. Name must match ^[a-z0-9-]+$ (kebab-case)."
+		exit 1
+	fi
+
+	echo "Codex manifest validation passed for plugin: ${plugin_name}"
+elif command -v node >/dev/null 2>&1; then
+	# Fallback to node for JSON validation
+	node - "${MANIFEST_PATH}" <<'EOF'
+const fs = require("fs");
+const manifestPath = process.argv[2];
+let manifest;
+
+try {
+  manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+} catch (error) {
+  console.error(`ERROR: Invalid JSON structure in ${manifestPath}: ${error.message}`);
+  process.exit(1);
+}
+
+const requiredFields = ["name", "version", "description"];
+for (const field of requiredFields) {
+  if (typeof manifest[field] !== "string" || manifest[field].trim() === "") {
+    console.error(`ERROR: Missing required non-empty string field '${field}' in ${manifestPath}.`);
+    process.exit(1);
+  }
+}
+
+if (!/^[a-z0-9-]+$/.test(manifest.name)) {
+  console.error(`ERROR: Invalid plugin name '${manifest.name}' in ${manifestPath}. Expected kebab-case matching ^[a-z0-9-]+$.`);
+  process.exit(1);
+}
+
+console.log(`Codex manifest validation passed for plugin: ${manifest.name}`);
+EOF
+else
+	echo "ERROR: Neither jq nor node is available for JSON validation"
+	exit 1
+fi

--- a/integration_tests/validate-cursor-manifest.sh
+++ b/integration_tests/validate-cursor-manifest.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 yu-iskw
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Validate Cursor plugin manifest JSON schema and required fields
+set -euo pipefail
+
+# Default plugin directory
+PLUGIN_DIR="${1:-.}"
+MANIFEST_PATH="${PLUGIN_DIR}/.cursor-plugin/plugin.json"
+
+# Check if manifest file exists
+if [[ ! -f ${MANIFEST_PATH} ]]; then
+	echo "ERROR: Cursor manifest file not found: ${MANIFEST_PATH}"
+	exit 1
+fi
+
+# Detect available JSON validator (prefer jq, fallback to node)
+if command -v jq >/dev/null 2>&1; then
+	# Validate JSON structure
+	if ! jq -e . "${MANIFEST_PATH}" >/dev/null 2>&1; then
+		echo "ERROR: Invalid JSON structure in ${MANIFEST_PATH}."
+		exit 1
+	fi
+
+	# Check required field: name
+	if ! jq -e '.name | type == "string" and length > 0' "${MANIFEST_PATH}" >/dev/null 2>&1; then
+		echo "ERROR: Missing required non-empty string field 'name' in ${MANIFEST_PATH}."
+		exit 1
+	fi
+
+	# Validate plugin name format (kebab-case)
+	plugin_name="$(jq -r '.name' "${MANIFEST_PATH}")"
+	if ! jq -e '.name | test("^[a-z0-9-]+$")' "${MANIFEST_PATH}" >/dev/null 2>&1; then
+		echo "ERROR: Invalid plugin name '${plugin_name}'. Name must match ^[a-z0-9-]+$ (kebab-case)."
+		exit 1
+	fi
+
+	echo "Cursor manifest validation passed for plugin: ${plugin_name}"
+elif command -v node >/dev/null 2>&1; then
+	# Fallback to node for JSON validation
+	node - "${MANIFEST_PATH}" <<'EOF'
+const fs = require("fs");
+const manifestPath = process.argv[2];
+let manifest;
+
+try {
+  manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+} catch (error) {
+  console.error(`ERROR: Invalid JSON structure in ${manifestPath}: ${error.message}`);
+  process.exit(1);
+}
+
+if (typeof manifest.name !== "string" || manifest.name.trim() === "") {
+  console.error(`ERROR: Missing required non-empty string field 'name' in ${manifestPath}.`);
+  process.exit(1);
+}
+
+if (!/^[a-z0-9-]+$/.test(manifest.name)) {
+  console.error(`ERROR: Invalid plugin name '${manifest.name}' in ${manifestPath}. Expected kebab-case matching ^[a-z0-9-]+$.`);
+  process.exit(1);
+}
+
+console.log(`Cursor manifest validation passed for plugin: ${manifest.name}`);
+EOF
+else
+	echo "ERROR: Neither jq nor node is available for JSON validation"
+	exit 1
+fi

--- a/plugins/hello-world/.codex-plugin/plugin.json
+++ b/plugins/hello-world/.codex-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "hello-world",
+  "version": "1.0.0",
+  "description": "Comprehensive sample plugin demonstrating all Codex extension points.",
+  "author": {
+    "name": "yu-iskw"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/yu-iskw/claude-code-plugin-template",
+  "skills": "./skills/"
+}

--- a/plugins/hello-world/.cursor-plugin/plugin.json
+++ b/plugins/hello-world/.cursor-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "hello-world",
+  "version": "1.0.0",
+  "description": "Comprehensive sample plugin demonstrating all Cursor extension points.",
+  "author": {
+    "name": "yu-iskw"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/yu-iskw/claude-code-plugin-template"
+}

--- a/plugins/hello-world/assets/icon.svg
+++ b/plugins/hello-world/assets/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <circle cx="32" cy="32" r="30" fill="#4A90E2" stroke="#2C5F8A" stroke-width="2"/>
+  <text x="32" y="38" font-family="sans-serif" font-size="20" font-weight="bold"
+        text-anchor="middle" fill="white">Hi</text>
+</svg>

--- a/plugins/hello-world/rules/hello-world.mdc
+++ b/plugins/hello-world/rules/hello-world.mdc
@@ -1,0 +1,22 @@
+---
+description: Hello World greeting standards and conventions
+globs:
+  - "**/*.md"
+  - "**/*.txt"
+alwaysApply: false
+---
+
+# Hello World Greeting Standards
+
+When generating or editing greeting content:
+
+- Use friendly, inclusive language
+- Prefer "Hello" or "Hi" over "Hey" in formal contexts
+- Always include the recipient's name when available
+- End greetings with a positive closing statement
+- Keep greetings concise — no more than 2 sentences
+
+## Examples
+
+Good: "Hello, Alice! Welcome to the project."
+Avoid: "Hey you, what's up?"


### PR DESCRIPTION
Extends the template to deliver plugins to three AI coding assistant
marketplaces using a multi-manifest pattern: each plugin directory can
optionally declare Cursor (.cursor-plugin/) and Codex (.codex-plugin/)
support alongside the existing Claude Code (.claude-plugin/) manifest.
Shared components (skills/, .mcp.json) live at the plugin root and are
reused across all platforms.

Changes:
- Add .cursor-plugin/plugin.json and .codex-plugin/plugin.json to hello-world
- Add hello-world/rules/hello-world.mdc (Cursor-specific AI guidance rule)
- Add hello-world/assets/icon.svg (Codex marketplace asset)
- Add top-level .cursor-plugin/marketplace.json and .codex-plugin/marketplace.json
- Add integration_tests/validate-cursor-manifest.sh and validate-codex-manifest.sh
- Update integration_tests/run.sh to run platform validations when manifests exist
- Add multi-platform-validation job to integration_tests.yml CI workflow
- Add .claude/skills/implement-cursor-plugin/SKILL.md
- Add .claude/skills/implement-codex-plugin/SKILL.md
- Update implement-plugin skill with Multi-Platform Support section
- Update implement-claude-extensions skill comparison table with Cursor/Codex rows

https://claude.ai/code/session_01CFJvoZ4RToRzJKWTTXBs3H