### PR TITLE
ci: reduce GitHub Actions runner usage

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -3,48 +3,48 @@ name: Integration Tests
 on:
   push:
     branches:
-      - "**"
+      - main
   pull_request: {} # yamllint disable-line empty-values
   workflow_dispatch: {} # yamllint disable-line empty-values
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
   plugin-install-test:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Plugin Install Integration Test
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
       - name: Setup Node.js 20
         uses: actions/setup-node@v6
         with:
           node-version: "20"
-
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
-
       - name: Run all plugin integration tests
         run: ./integration_tests/run.sh --verbose
 
   multi-platform-validation:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Multi-Platform Manifest Validation
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
       - name: Install jq
         run: sudo apt-get install -y jq
-
       - name: Run multi-platform manifest validation
         run: ./integration_tests/run.sh --manifest-only --verbose
 
   plugin-install-docker:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Plugin Install in Docker
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -16,7 +16,6 @@ permissions:
 
 jobs:
   plugin-install-test:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Plugin Install Integration Test
     runs-on: ubuntu-latest
     steps:
@@ -32,7 +31,6 @@ jobs:
         run: ./integration_tests/run.sh --verbose
 
   multi-platform-validation:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Multi-Platform Manifest Validation
     runs-on: ubuntu-latest
     steps:
@@ -44,7 +42,6 @@ jobs:
         run: ./integration_tests/run.sh --manifest-only --verbose
 
   plugin-install-docker:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Plugin Install in Docker
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/trunk_check.yml
+++ b/.github/workflows/trunk_check.yml
@@ -25,7 +25,6 @@ permissions: read-all
 
 jobs:
   trunk_check:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Trunk Check Runner
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/trunk_check.yml
+++ b/.github/workflows/trunk_check.yml
@@ -25,15 +25,14 @@ permissions: read-all
 
 jobs:
   trunk_check:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Trunk Check Runner
     runs-on: ubuntu-latest
     permissions:
-      checks: write # For trunk to post annotations
-      contents: read # For repo checkout
-
+      checks: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1


### PR DESCRIPTION
## Summary

Apply the public runner-efficiency policy to the plugin template itself.

- stop integration tests from running on every branch push; keep `main` push and PR coverage
- preserve host-install, manifest-validation, and Docker-install lanes
- skip integration and Trunk jobs while a PR is draft
- cancel superseded integration runs
- leave Trunk-upgrade behavior unchanged

New repositories based on this template will inherit the leaner trigger policy.